### PR TITLE
streams: fix subscription keepalive parsing

### DIFF
--- a/stream_pub.go
+++ b/stream_pub.go
@@ -99,11 +99,11 @@ func (s *PublisherStream) keepalive() {
 		case <-s.ctx.Done():
 			return
 		case <-t.C:
-			_, err := s.c.Call(s.address, &m.Message{To: m.TopicRemoteStartPublisher, Data: m.StreamCreateMsg{
+			err := s.c.Call2(s.address, &m.Message{To: m.TopicRemoteStartPublisher, Data: m.StreamCreateMsg{
 				Id:          s.pubId,
 				Timeout:     s.timeout,
 				PayloadOnly: s.payloadOnly,
-			}}, time.Second*5)
+			}}, nil, time.Second*5)
 			if err != nil && !ie.ErrTimeout.Is(err) {
 				s.cancel(err)
 				return

--- a/stream_sub.go
+++ b/stream_sub.go
@@ -109,11 +109,11 @@ func (s *SubscriberStream) keepalive() {
 		case <-s.ctx.Done():
 			return
 		case <-t.C:
-			_, err := s.c.Call(s.address, &m.Message{To: m.TopicRemoteSubscribe, Data: m.StreamCreateMsg{
+			err := s.c.Call2(s.address, &m.Message{To: m.TopicRemoteSubscribe, Data: m.StreamCreateMsg{
 				Id:          s.subId,
 				Timeout:     s.timeout,
 				PayloadOnly: s.payloadOnly,
-			}}, time.Second*5)
+			}}, nil, time.Second*5)
 			if err != nil && !ie.ErrTimeout.Is(err) {
 				s.cancel(err)
 				return


### PR DESCRIPTION
When sending the keepalive for a subscription, `Call()` instead of `Call2()` was being used. This meant that the receiver would fail at decoding some field types such as`time.Duration`.

`Call2()` calls `m.ToMsi()` on `msg.Data` before calling `Call()`.

In the following image there is a log of the buggy behaviour when printing the TIMEOUT variable:

![Captura desde 2024-11-25 17-15-38](https://github.com/user-attachments/assets/b881de17-9b48-4cd7-95c9-71a6f611db6a)

I have modified the Publisher keepalive too.
